### PR TITLE
chore: add workflows

### DIFF
--- a/.github/workflows/get-go-version.yml
+++ b/.github/workflows/get-go-version.yml
@@ -1,0 +1,30 @@
+name: Get Go Version
+
+on:
+  workflow_call:
+    outputs:
+      go-version:
+        description: The Go version in the go.mod file
+        value: ${{ jobs.get-go-version.outputs.go-version }}
+      
+permissions:
+  contents: read
+
+jobs:
+
+  get-go-version:
+    name: Get Go Version
+    runs-on: ubuntu-latest
+
+    outputs:
+      go-version: ${{ steps.get-go-version.outputs.go-version }}
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Go Version
+        id: get-go-version
+        run: |
+          go_version=$(grep '^go' < go.mod | cut -d' ' -f2)
+          echo "go-version=${go_version}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/go-fmt.yml
+++ b/.github/workflows/go-fmt.yml
@@ -1,0 +1,33 @@
+name: Go Fmt
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+      
+permissions:
+  contents: read
+
+jobs:
+
+  go-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Go Fmt
+        run: |
+          changed="$(go fmt ./...)"
+          if [[ -n "${changed}" ]]; then
+            echo "The following files need to be formatted with go fmt:"
+            sed 's/^/  - /g' <<< ${changed}
+            exit 1
+          fi

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,27 @@
+name: Go Test
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Go Test
+        run: go test ./...

--- a/.github/workflows/go-vet.yml
+++ b/.github/workflows/go-vet.yml
@@ -1,0 +1,27 @@
+name: Go Vet
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+
+  go-vet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Go Vet
+        run: go vet ./...

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,39 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+    
+permissions:
+  contents: read
+
+jobs:
+
+  get-go-version:
+    name: Get Go Version
+    uses: ./.github/workflows/get-go-version.yml
+
+  go-test:
+    name: Go Test
+    needs:
+      - get-go-version
+    uses: ./.github/workflows/go-test.yml
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+
+  go-vet:
+    name: Go Vet
+    needs:
+      - get-go-version
+    uses: ./.github/workflows/go-vet.yml
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+
+  go-fmt:
+    name: Go Fmt
+    needs:
+      - get-go-version
+    uses: ./.github/workflows/go-fmt.yml
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ttd2089/garlic
+
+go 1.23.1

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	num := 0
+	for _, c := range "string" {
+		num <<= 8
+		num += int(c)
+	}
+
+	fmt.Printf("My favourite number is %d.\n", num)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestSanity(t *testing.T) {
+	if 2+2 != 4 {
+		t.Fatalf("Winston, no!")
+	}
+}


### PR DESCRIPTION
Adds reusable workflows for running tests, running go vet, and running
go fmt on changed files, and a pull request workflow that runs them all.
The individual steps are reusable workflows instead of inline in the
pull request workflow so the test and vet steps can be reused in an
on-push workflow to create issues if there are somehow broken tests or
vet issues in main without without worrying about the fmt step.

There's also a get-go-version workflow that injects the go version from
the go mod into the workflows so they're always in sync.