### PR TITLE
feat: root-level resolution and default factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ The default factory for `bool`, numeric, array, and string types provide the zer
 
 The default factory for channels provides an unbuffered channel.
 
-The default factory for maps is equivalent to `make(map[T]U)`.
+The default factory for maps is equivalent to `make(map[T]U)`. This ensures that the returned value can be written to.
 
-The default factory for slices is equivalent to `make([]T, 0)`.
+The default factory for slices returns `nil`. Unlike with maps, a `nil` slice can be appended to. A zero-length slice can only be written to with an append so semantically there's no difference between `nil` and an empty slice.
 
 Default factories are unavailable for types whose direct [`reflect.Kind`][reflect.Kind] is [`reflect.Uintptr`], [`reflect.Func`], or [`reflect.UnsafePointer`].
 

--- a/pkg/di/default_factory.go
+++ b/pkg/di/default_factory.go
@@ -1,0 +1,103 @@
+package di
+
+import (
+	"errors"
+	"reflect"
+)
+
+// GetDefaultFactory returns the default factory for the requested type, or [ErrNoDefaultFactory]
+// if the type has no default factory.
+func GetDefaultFactory[T any]() (Factory[T], error) {
+	typ := reflect.TypeFor[T]()
+	factory, err := getDefaultFactory(typ)
+	if err != nil {
+		return nil, err
+	}
+	return func(r Resolver) (T, error) {
+		v, err := factory(r)
+		if err != nil {
+			var zero T
+			return zero, err
+		}
+		return v.(T), nil
+	}, nil
+}
+
+func getDefaultFactory(typ reflect.Type) (factoryFunc, error) {
+	switch typ.Kind() {
+	case
+		reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64,
+		reflect.Complex64, reflect.Complex128,
+		reflect.Array,
+		reflect.String,
+		reflect.Slice:
+		return func(Resolver) (any, error) {
+			return reflect.Zero(typ).Interface(), nil
+		}, nil
+	case reflect.Map:
+		return func(Resolver) (any, error) {
+			return reflect.MakeMap(typ).Interface(), nil
+		}, nil
+	case reflect.Chan:
+		return func(Resolver) (any, error) {
+			return reflect.MakeChan(typ, 0).Interface(), nil
+		}, nil
+	case reflect.Struct:
+		return getDefaultStructFactory(typ)
+	case reflect.Pointer:
+		return getDefaultPointerFactory(typ)
+	}
+
+	return nil, NoDefaultFactory{
+		Type: typ,
+	}
+}
+
+func getDefaultStructFactory(typ reflect.Type) (factoryFunc, error) {
+	return func(r Resolver) (any, error) {
+		val := reflect.New(typ)
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			resolved, err := r.Resolve(field.Type)
+			if err != nil {
+				return nil, resolverError{wrapped: err}
+			}
+			resolvedType := reflect.TypeOf(resolved)
+			if resolvedType == nil || !resolvedType.AssignableTo(field.Type) {
+				return nil, InvalidResolution{
+					Requested: field.Type,
+					Returned:  reflect.TypeOf(resolved),
+				}
+			}
+			val.Elem().Field(i).Set(reflect.ValueOf(resolved))
+		}
+		return val.Elem().Interface(), nil
+	}, nil
+}
+
+func getDefaultPointerFactory(typ reflect.Type) (factoryFunc, error) {
+	elemFactory, err := getDefaultFactory(typ.Elem())
+	if errors.Is(err, ErrNoDefaultFactory) {
+		return nil, NoDefaultFactory{
+			Type: typ,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return func(r Resolver) (any, error) {
+		v, err := elemFactory(r)
+		if err != nil {
+			return nil, err
+		}
+		pVal := reflect.New(typ.Elem())
+		pVal.Elem().Set(reflect.ValueOf(v))
+		return pVal.Interface(), nil
+	}, nil
+}

--- a/pkg/di/default_factory_test.go
+++ b/pkg/di/default_factory_test.go
@@ -1,0 +1,390 @@
+package di
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+// asFactoryFunc returns the result of GetDefaultFactory as a factoryFunc. This enables us to write
+// cases for GetDefaultFactory with differing type parameters in a single set of table test cases.
+func asFactoryFunc[T any](in func() (Factory[T], error)) func() (factoryFunc, error) {
+	return func() (factoryFunc, error) {
+		factory, err := in()
+		if err != nil {
+			return nil, err
+		}
+		return func(r Resolver) (any, error) {
+
+			value, err := factory(r)
+			if err != nil {
+				var zero T
+				return zero, err
+			}
+			return value, nil
+		}, nil
+	}
+}
+
+func Test_getDefaultFactory(t *testing.T) {
+
+	t.Run("no default factory", func(t *testing.T) {
+
+		testCases := []struct {
+			getDefaultFactory func() (factoryFunc, error)
+			typ               reflect.Type
+		}{
+			{
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[uintptr]),
+				typ:               reflect.TypeFor[uintptr](),
+			},
+			{
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[func()]),
+				typ:               reflect.TypeFor[func()](),
+			},
+			{
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[unsafe.Pointer]),
+				typ:               reflect.TypeFor[unsafe.Pointer](),
+			},
+			{
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[*uintptr]),
+				typ:               reflect.TypeFor[*uintptr](),
+			},
+			{
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[*func()]),
+				typ:               reflect.TypeFor[*func()](),
+			},
+			{
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[*unsafe.Pointer]),
+				typ:               reflect.TypeFor[*unsafe.Pointer](),
+			},
+		}
+
+		for _, tt := range testCases {
+			t.Run(fmt.Sprintf("returns NoDefaultFactory for %T", tt.typ), func(t *testing.T) {
+				_, err := tt.getDefaultFactory()
+				if !errors.Is(err, ErrNoDefaultFactory) {
+					t.Fatalf("expected %q; got %q", ErrNoDefaultFactory, err)
+				}
+				var noDefaultFactory NoDefaultFactory
+				if !errors.As(err, &noDefaultFactory) {
+					t.Fatalf("expected %v to be %T", err, noDefaultFactory)
+				}
+				if typ := tt.typ; noDefaultFactory.Type != typ {
+					t.Errorf("expected err.Type to be %v; got %v", typ, noDefaultFactory.Type)
+				}
+			})
+		}
+	})
+
+	t.Run("default factory for", func(t *testing.T) {
+
+		type decision bool
+
+		testCases := []struct {
+			name              string
+			getDefaultFactory func() (factoryFunc, error)
+			typ               reflect.Type
+			expected          any
+		}{
+			{
+				name:              "bool returns false",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[bool]),
+				expected:          false,
+			},
+			{
+				name:              "pointer to bool returns pointer to false",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[*bool]),
+				expected: func() *bool {
+					b := false
+					return &b
+				}(),
+			},
+			{
+				name:              "pointer to pointer to bool returns pointer to pointer to false",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[**bool]),
+				expected: func() **bool {
+					b := false
+					p := &b
+					return &p
+				}(),
+			},
+			{
+				name:              "type defined as bool returns false",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[decision]),
+				expected:          decision(false),
+			},
+			{
+				name:              "int returns zero",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[int]),
+				expected:          int(0),
+			},
+			{
+				name:              "array returns array of zero-values",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[[3]int]),
+				expected:          [3]int{},
+			}, {
+				name:              "pointer to array returns pointer to array of zero-values",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[*[3]int]),
+				expected:          &[3]int{},
+			},
+			{
+				name:              "pointer to string returns pointer to \"\"",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[*string]),
+				expected: func() *string {
+					s := ""
+					return &s
+				}(),
+			},
+			{
+				name:              "slice returns nil",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[[]int]),
+				expected: func() []int {
+					return nil
+				}(),
+			},
+			{
+				name:              "pointer to slice returns non-nil pointer to nil",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[*[]int]),
+				expected: func() *[]int {
+					var s []int
+					return &s
+				}(),
+			},
+			{
+				name:              "map returns empty map",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[map[int]string]),
+				expected:          make(map[int]string),
+			},
+			{
+				name:              "pointer to map returns pointer to empty map",
+				getDefaultFactory: asFactoryFunc(GetDefaultFactory[*map[int]string]),
+				expected:          &map[int]string{},
+			},
+		}
+
+		for _, tt := range testCases {
+			t.Run(tt.name, func(t *testing.T) {
+				factory, err := tt.getDefaultFactory()
+				if err != nil {
+					t.Fatalf("unexpected error getting factory: %v", err)
+				}
+				v, err := factory(nil)
+				if err != nil {
+					t.Fatalf("unexpected error from factory: %v", err)
+				}
+				if !reflect.DeepEqual(v, tt.expected) {
+					t.Fatalf("expected %#[1]v (%[1]T); got %#[2]v (%[2]T)", tt.expected, v)
+				}
+			})
+		}
+
+		// Identical channels aren't considered equal so we needed a custom body for this case.
+		t.Run("chan returns unbuffered chan", func(t *testing.T) {
+			factory, err := GetDefaultFactory[chan int]()
+			if err != nil {
+				t.Fatalf("unexpected error getting factory: %v", err)
+			}
+			ch, err := factory(nil)
+			if err != nil {
+				t.Fatalf("unexpected error from factory: %v", err)
+			}
+			if len := cap(ch); len != 0 {
+				t.Fatalf("expected unbuffered chan; got %d-element buffer", len)
+			}
+		})
+
+		t.Run("struct returns instance of struct", func(t *testing.T) {
+
+			factory, err := GetDefaultFactory[struct{}]()
+			if err != nil {
+				t.Fatalf("unexpected error getting factory: %v", err)
+			}
+			_, err = factory(nil)
+			if err != nil {
+				t.Fatalf("unexpected error from factory: %v", err)
+			}
+		})
+
+		t.Run("struct initializes exported fields with resolver", func(t *testing.T) {
+
+			expectedWidget := widget{
+				X: 42,
+				y: 1.618,
+			}
+			expectedGadget := gadget{
+				Names: map[int]string{
+					1: "one",
+					2: "two",
+				},
+				counts: map[string]int{
+					"three": 3,
+					"four":  4,
+				},
+			}
+
+			resolver := testResolver{
+				resolutions: map[reflect.Type]testResolverResolution{
+					reflect.TypeFor[widget](): {
+						val: expectedWidget,
+					},
+					reflect.TypeFor[*gadget](): {
+						val: &expectedGadget,
+					},
+				},
+			}
+
+			expected := thing{
+				Widget: expectedWidget,
+				Gadget: &expectedGadget,
+			}
+
+			factory, _ := GetDefaultFactory[thing]()
+
+			thing, err := factory(resolver)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(thing, expected) {
+				t.Fatalf("expected %v; got %v", expected, thing)
+			}
+		})
+
+		t.Run("struct does not initialize unexported fields", func(t *testing.T) {
+			expected := unexportedFieldsOnly{}
+			factory, _ := GetDefaultFactory[unexportedFieldsOnly]()
+
+			ufo, err := factory(testResolver{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(ufo, expected) {
+				t.Fatalf("expected %v; got %v", expected, ufo)
+			}
+		})
+
+		t.Run("struct does not initialize exported fields recursively", func(t *testing.T) {
+
+			unexpectedWidget := widget{
+				X: 13,
+				y: 3.14,
+			}
+			unexpectedGadget := gadget{
+				Names: map[int]string{
+					11: "eleven",
+					12: "twelve",
+				},
+				counts: map[string]int{
+					"thirteen": 13,
+					"fourteen": 14,
+				},
+			}
+
+			expectedThing := thing{
+				Widget: widget{
+					X: 42,
+					y: 1.618,
+				},
+				Gadget: &gadget{
+					Names: map[int]string{
+						1: "one",
+						2: "two",
+					},
+					counts: map[string]int{
+						"three": 3,
+						"four":  4,
+					},
+				},
+			}
+
+			expected := recursiveStruct{
+				Thing: expectedThing,
+			}
+
+			resolver := testResolver{
+				resolutions: map[reflect.Type]testResolverResolution{
+					reflect.TypeFor[widget](): {
+						val: unexpectedWidget,
+					},
+					reflect.TypeFor[*gadget](): {
+						val: &unexpectedGadget,
+					},
+					reflect.TypeFor[thing](): {
+						val: expectedThing,
+					},
+				},
+			}
+
+			factory, _ := GetDefaultFactory[recursiveStruct]()
+
+			rs, _ := factory(resolver)
+
+			if !reflect.DeepEqual(rs, expected) {
+				t.Fatalf("expected %v; got %v", expected, rs)
+			}
+
+		})
+
+		t.Run("pointer to struct returns non-nil pointer to struct", func(t *testing.T) {
+
+			factory, err := GetDefaultFactory[*unexportedFieldsOnly]()
+			if err != nil {
+				t.Fatalf("unexpected error getting factory: %v", err)
+			}
+			pufo, err := factory(testResolver{})
+			if err != nil {
+				t.Fatalf("unexpected error from factory: %v", err)
+			}
+			if pufo == nil {
+				t.Fatalf("expected non-nil %[1]T; got %[1]v", pufo)
+			}
+		})
+
+	})
+}
+
+type testResolver struct {
+	resolutions map[reflect.Type]testResolverResolution
+}
+
+type testResolverResolution struct {
+	val any
+	err error
+}
+
+func (r testResolver) Resolve(typ reflect.Type) (any, error) {
+	if v, ok := r.resolutions[typ]; ok {
+		return v.val, v.err
+	}
+	return nil, fmt.Errorf("unexpected call: testResolver.Resolve(%v)", typ)
+}
+
+type widget struct {
+	X int
+	y float64
+}
+
+type gadget struct {
+	Names  map[int]string
+	counts map[string]int
+}
+
+type thing struct {
+	Widget widget
+	Gadget *gadget
+}
+
+type unexportedFieldsOnly struct {
+	//lint:ignore U1000 Testing that unexported fields are not initialized.
+	widget widget
+	//lint:ignore U1000 Testing that unexported fields are not initialized.
+	gadget *gadget
+}
+
+type recursiveStruct struct {
+	Thing thing
+}

--- a/pkg/di/resolve.go
+++ b/pkg/di/resolve.go
@@ -1,0 +1,100 @@
+package di
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// ErrNilResolver is returned when the [Resolve] function receives a nil [Resolver] argument.
+var ErrNilResolver = errors.New("cannot resolve instances from nil Resolver")
+
+// ErrResolverError is returned when the [Resolve] function receives an error from a [Resolver].
+var ErrResolverError = errors.New("Resolver returned error")
+
+type resolverError struct {
+	wrapped error
+}
+
+// Error implements [error].
+func (err resolverError) Error() string {
+	return fmt.Sprintf("resolver error: %v", err.wrapped)
+}
+
+// Is indicates that a [resolverError] is [ErrResolverError].
+func (resolverError) Is(target error) bool {
+	return target == ErrResolverError
+}
+
+// Unwrap gets the underlying [error] from the [Resolver].
+func (err resolverError) Unwrap() error {
+	return err.wrapped
+}
+
+// ErrInvalidResolution is returned when the [Resolve] function receives a value from a [Resolver]
+// that cannot be assigned to the requested type.
+//
+// NOTE: This error ALWAYS points to a broken implementation of [Resolver]. The contract of
+// [Resolver] requires returned values to be assignable to the requested type, but the absence of
+// generic methods in Go's type system prevents this from being enforced statically.
+var ErrInvalidResolution = errors.New("value from Resolver does not have requested type")
+
+// A InvalidResolution is an [error] indicating that a [Resolver] returned a a value that could not
+// be assigned to the requested type. Calling [errors.Is] with an [InvalidResolution] and
+// [ErrInvalidResolution] returns true.
+type InvalidResolution struct {
+
+	// Requested is the type that was requested from the [Resolver].
+	Requested reflect.Type
+
+	// Returned is the type of the value the [Resolver] returned.
+	Returned reflect.Type
+}
+
+// Error implements [error].
+func (err InvalidResolution) Error() string {
+	return fmt.Sprintf(
+		"value from Resolver has type %v when %v was requested",
+		err.Returned,
+		err.Requested)
+}
+
+// Is indicates that an [InvalidResolution] is [ErrInvalidResolution].
+func (InvalidResolution) Is(target error) bool {
+	return target == ErrInvalidResolution
+}
+
+// A Resolver resolves instances of a requested type.
+type Resolver interface {
+
+	// Resolve provides an instance of the requested type if one is registered. Implementations
+	// MUST ensure that the values returned are assignable to the requested type.
+	Resolve(reflect.Type) (any, error)
+}
+
+// Resolve obtains an instance of the requested type from a [Resolver]. An [error] is returned when
+// the [Resolver] returns an [error] or a value that is not assignable to T.
+func Resolve[T any](resolver Resolver) (T, error) {
+	if resolver == nil {
+		var zero T
+		return zero, ErrNilResolver
+	}
+
+	var zero T
+	typ := reflect.TypeFor[T]()
+
+	resolved, err := resolver.Resolve(typ)
+	if err != nil {
+		return zero, resolverError{wrapped: err}
+	}
+
+	typed, ok := resolved.(T)
+	if !ok {
+		return zero, InvalidResolution{
+			Requested: typ,
+			Returned:  reflect.TypeOf(resolved),
+		}
+	}
+
+	return typed, nil
+}

--- a/pkg/di/resolve_test.go
+++ b/pkg/di/resolve_test.go
@@ -1,0 +1,99 @@
+package di
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+
+	t.Run("returns ErrNilResolver when Resolver is nil", func(t *testing.T) {
+		if _, err := Resolve[interface{}](nil); !errors.Is(err, ErrNilResolver) {
+			t.Fatalf("expected %v; got %v", ErrNilResolver, err)
+		}
+	})
+
+	t.Run("requests an instance of the type T from the Resolver", func(t *testing.T) {
+		expected := reflect.TypeFor[interface{}]()
+		resolver := mockResolver{}
+		resolver.returns(&struct{}{}, nil)
+		_, _ = Resolve[interface{}](&resolver)
+		if resolver.requestedTypes[0] != expected {
+			t.Errorf("expected %v; got %v", expected, resolver.requestedTypes[0])
+		}
+	})
+
+	t.Run("returns ErrResolverError when the Resolver returns an error", func(t *testing.T) {
+		expectedErr := errors.New("expected error")
+		resolver := mockResolver{}
+		resolver.returns(struct{}{}, expectedErr)
+		_, actualErr := Resolve[struct{}](&resolver)
+		if !errors.Is(actualErr, ErrResolverError) {
+			t.Errorf("expected %v; got %v", expectedErr, ErrResolverError)
+		}
+		if !errors.Is(actualErr, expectedErr) {
+			t.Errorf("expected %v; got %v", expectedErr, actualErr)
+		}
+	})
+
+	t.Run("returns ErrInvalidResolution when the returned value is not assignable to requested to type", func(t *testing.T) {
+		resolver := mockResolver{}
+		resolver.returns(struct{}{}, nil)
+		_, err := Resolve[string](&resolver)
+		if !errors.Is(err, ErrInvalidResolution) {
+			t.Errorf("expected %v; got %v", ErrInvalidResolution, err)
+		}
+		var invalidType InvalidResolution
+		if !errors.As(err, &invalidType) {
+			t.Fatalf("expected %v to be %T", err, invalidType)
+		}
+		if strType := reflect.TypeFor[string](); invalidType.Requested != strType {
+			t.Errorf("expected err.Actual to be %v; got %v", strType, invalidType.Requested)
+		}
+		if structType := reflect.TypeFor[struct{}](); invalidType.Returned != structType {
+			t.Errorf("expected err.Actual to be %v; got %v", structType, invalidType.Returned)
+		}
+	})
+
+	t.Run("returns the resolved value when its assignable to requested type", func(t *testing.T) {
+		expected := &struct{}{}
+		resolver := mockResolver{}
+		resolver.returns(expected, nil)
+		actual, err := Resolve[interface{}](&resolver)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if actual != expected {
+			t.Errorf("expected %v; got %v", expected, actual)
+		}
+	})
+}
+
+type mockResolver struct {
+	returnValues []struct {
+		v   any
+		err error
+	}
+	requestedTypes []reflect.Type
+}
+
+func (mock *mockResolver) returns(v any, err error) {
+	mock.returnValues = append(mock.returnValues, struct {
+		v   any
+		err error
+	}{
+		v:   v,
+		err: err,
+	})
+}
+
+func (mock *mockResolver) Resolve(typ reflect.Type) (any, error) {
+	mock.requestedTypes = append(mock.requestedTypes, typ)
+	if len(mock.returnValues) == 0 {
+		panic("no return values configured")
+	}
+	r := mock.returnValues[0]
+	mock.returnValues = mock.returnValues[1:]
+	return r.v, r.err
+}

--- a/pkg/di/root_provider.go
+++ b/pkg/di/root_provider.go
@@ -1,0 +1,122 @@
+package di
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// ErrUnknownType is returned when an attempt is made to resolve a value from a provider but the
+// requested type is unknown.
+var ErrUnknownType = errors.New("requested type is unknown")
+
+// An UnknownType is an [error] indicating that an attempt was made to resolve a value from a
+// provider but the requested type was unknown. Calling [errors.Is] with a [UnknownType] and
+// [ErrUnknownType] returns true.
+type UnknownType struct {
+
+	// Type is the unknown type.
+	Type reflect.Type
+}
+
+// Error implements [error].
+func (err UnknownType) Error() string {
+	return fmt.Sprintf("requested type %v is unknown to the provider", err.Type)
+}
+
+// Is indicates that a [UnknownType] is [ErrUnknownType].
+func (err UnknownType) Is(target error) bool {
+	return target == ErrUnknownType
+}
+
+// ErrScopedValueRequestedFromRootProvider is returned when an attempt is made to resolve a scoped
+// value from a [RootProvider].
+var ErrScopedValueRequestedFromRootProvider = errors.New("RootProvider cannot resolve a scoped value")
+
+// A ScopedValueRequestedFromRootProvider is an [error] indicating that an attempt was made to
+// resolve a scoped value from a [RootProvider]. Calling [errors.Is] with a
+// [ScopedValueRequestedFromRootProvider] and [ErrScopedValueRequestedFromRootProvider] returns
+// true.
+type ScopedValueRequestedFromRootProvider struct {
+
+	// Type is the unknown type.
+	Type reflect.Type
+}
+
+// Error implements [error].
+func (err ScopedValueRequestedFromRootProvider) Error() string {
+	return fmt.Sprintf("RootProvider cannot resolve a scoped value of type %v", err.Type)
+}
+
+// Is indicates that a [ScopedValueRequestedFromRootProvider] is [ErrScopedValueRequestedFromRootProvider].
+func (err ScopedValueRequestedFromRootProvider) Is(target error) bool {
+	return target == ErrScopedValueRequestedFromRootProvider
+}
+
+// A RootProvider is a [Provider] that can resolve [Transient] and [Singleton] values.
+type RootProvider struct {
+	registrations map[reflect.Type]registration
+	singletons    *instanceMap
+}
+
+func (provider RootProvider) Resolve(typ reflect.Type) (any, error) {
+	registration, ok := provider.registrations[typ]
+	if !ok {
+		return nil, fmt.Errorf("no implementation registered for service type %v", typ)
+	}
+	switch registration.lifetime {
+	case Transient:
+		return registration.factory(provider)
+	case Scoped:
+		return nil, ScopedValueRequestedFromRootProvider{
+			Type: typ,
+		}
+	case Singleton:
+		return provider.resolveSingleton(typ, registration.factory)
+	default:
+		panic("this code should be unreachable: please open a an issue at https://github.com/ttd2089/stahp/issues/new")
+	}
+}
+
+func (provider RootProvider) resolveSingleton(typ reflect.Type, factory factoryFunc) (any, error) {
+	return provider.singletons.resolve(typ, factory, provider)
+}
+
+type instanceMap struct {
+	mu        sync.RWMutex
+	instances map[reflect.Type]any
+}
+
+func (m *instanceMap) resolve(
+	typ reflect.Type,
+	factory factoryFunc,
+	resolver Resolver,
+) (any, error) {
+	if v, ok := m.get(typ); ok {
+		return v, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// We may have resolved and saved a singleton instance while we were waiting for a lock so check again.
+	if service, ok := m.instances[typ]; ok {
+		return service, nil
+	}
+	// Build, save, and return the scoped instance.
+	service, err := factory(resolver)
+	if err != nil {
+		return nil, err
+	}
+	if m.instances == nil {
+		m.instances = make(map[reflect.Type]any)
+	}
+	m.instances[typ] = service
+	return service, nil
+}
+
+func (m *instanceMap) get(typ reflect.Type) (any, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.instances[typ]
+	return v, ok
+}

--- a/pkg/di/root_provider_test.go
+++ b/pkg/di/root_provider_test.go
@@ -1,0 +1,85 @@
+package di
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestRootProvider(t *testing.T) {
+
+	t.Run("Resolve", func(t *testing.T) {
+
+		// distinctCapableStruct is required to observe whether pointers point to the same instance
+		// or not because pointers to zero-length structs can be equal even when the pointed values
+		// are distinct.
+		//
+		// From the Golang spec:
+		// Pointer types are comparable. Two pointer values are equal if they point to the same
+		// variable or if both have value nil. Pointers to distinct zero-size variables may or may
+		// not be equal.
+		type distinctCapableStruct struct {
+			//lint:ignore U1000 Field enabled type to be distinct
+			x int
+		}
+
+		t.Run("scoped instances cannot be resolved from RootProvider", func(t *testing.T) {
+			registry, err := RegisterType[*distinctCapableStruct, *distinctCapableStruct](Registry{}, Scoped)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			_, err = provider.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if !errors.Is(err, ErrScopedValueRequestedFromRootProvider) {
+				t.Fatalf("expected err=%v; got %v", ErrScopedValueRequestedFromRootProvider, err)
+			}
+		})
+
+		t.Run("transient instances from the same provider are distinct", func(t *testing.T) {
+			registry, err := RegisterType[*distinctCapableStruct, *distinctCapableStruct](Registry{}, Transient)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			a, err := provider.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			b, err := provider.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			if a == b {
+				t.Fatalf("instances are the same: %p %p", a, b)
+			}
+		})
+
+		t.Run("singleton instances from the same provider are the same", func(t *testing.T) {
+			registry, err := RegisterType[*distinctCapableStruct, *distinctCapableStruct](Registry{}, Singleton)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			a, err := provider.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			b, err := provider.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			if a != b {
+				t.Fatalf("instances are not the same: %p %p", a, b)
+			}
+		})
+	})
+}


### PR DESCRIPTION
Implements a RootProvider type that can be built from a Registry and used to resolve Transient and Singleton instances, and a strongly-typed generic Resolve function to obtain typed values from Resolvers.

Implements default factories for types as described in the README.