### PR TITLE
feat: scoped resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Many applications can benefit from using request-scoped values. In that case the
 - Resolve the values start accepting requests from the [`di.RootProvider`][di.RootProvider]
 - Start accepting requests
 - For each request:
-  - Create a [`di.ScopedProvider`][di.ScopedProvider] from the [`di.RootProvider`][di.RootProvider]
-  - Resolve the values required to handle the request from the [`di.ScopedProvider`][di.ScopedProvider]
+  - Create a [`di.Scope`][di.Scope] from the [`di.RootProvider`][di.RootProvider]
+  - Resolve the values required to handle the request from the [`di.Scope`][di.Scope]
   - Handle the request
 
 ## Concepts
@@ -48,7 +48,7 @@ An implementation type is the concrete type of the value that will be resolved w
 
 A [`di.Resolver`][di.Resolver] is a value that resolves instances of various types on demand at runtime.
 
-The [`di`][di] package provides two [`di.Resolver`][di.Resolver] implementations: [`di.RootProvider`][di.RootProvider] and [`di.ScopedProvider`][di.ScopedProvider].
+The [`di`][di] package provides two [`di.Resolver`][di.Resolver] implementations: [`di.RootProvider`][di.RootProvider] and [`di.Scope`][di.Scope].
 
 ### Factories
 
@@ -82,7 +82,7 @@ A [`di.Lifetime`][di.Lifetime] describes when a [`di.Resolver`][di.Resolver] sho
 
 The [`di.Transient`][di.Transient] [lifetime][di.Lifetime] specifies that a new value should be initialized every time a type is resolved and can be used with any type.
 
-The [`di.Scoped`][di.Scoped] [lifetime][di.Lifetime] specifies that a single instance of the registered type should be reused every time the type is resolved from the same [`di.ScopedProvider`][di.ScopedProvider], and the [`di.Singleton`][di.Singleton] [lifetime][di.Lifetime] specifies that a single instance should be reused every time the type is resolved from the same [`di.RootProvider`][di.RootProvider] or any [`di.ScopedProvider`][di.ScopedProvider] created from it. In order to support reusing the same instance the [`di.Scoped`][di.Scoped] and [`di.Singleton`][di.Singleton] [lifetimes][di.Lifetime] can only be used with [sharable types](#sharable-types).
+The [`di.Scoped`][di.Scoped] [lifetime][di.Lifetime] specifies that a single instance of the registered type should be reused every time the type is resolved from the same [`di.Scope`][di.Scope], and the [`di.Singleton`][di.Singleton] [lifetime][di.Lifetime] specifies that a single instance should be reused every time the type is resolved from the same [`di.RootProvider`][di.RootProvider] or any [`di.Scope`][di.Scope] created from it. In order to support reusing the same instance the [`di.Scoped`][di.Scoped] and [`di.Singleton`][di.Singleton] [lifetimes][di.Lifetime] can only be used with [sharable types](#sharable-types).
 
 ### Sharable Types
 
@@ -107,7 +107,7 @@ Maps are currently _not_ considered sharable. Although maps hold heir data in an
 [di.Resolver]: https://pkg.go.dev/github.com/ttd2089/garlic/pkg/di#Resolver
 [di.RootProvider]: https://pkg.go.dev/github.com/ttd2089/garlic/pkg/di#Provider
 [di.Singleton]: https://pkg.go.dev/github.com/ttd2089/garlic/pkg/di#Singleton
-[di.ScopedProvider]: https://pkg.go.dev/github.com/ttd2089/garlic/pkg/di#ScopedProvider
+[di.Scope]: https://pkg.go.dev/github.com/ttd2089/garlic/pkg/di#Scope
 [di.Scoped]: https://pkg.go.dev/github.com/ttd2089/garlic/pkg/di#Scoped
 [di.Transient]: https://pkg.go.dev/github.com/ttd2089/garlic/pkg/di#Transient
 

--- a/pkg/di/instance_map.go
+++ b/pkg/di/instance_map.go
@@ -1,0 +1,54 @@
+package di
+
+import (
+	"reflect"
+	"sync"
+)
+
+type instanceMap struct {
+	mu        sync.RWMutex
+	instances map[reflect.Type]any
+}
+
+func (m *instanceMap) resolve(
+	typ reflect.Type,
+	factory factoryFunc,
+	resolver Resolver,
+) (any, error) {
+	if v, ok := m.get(typ); ok {
+		return v, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// We may have resolved and saved a singleton instance while we were waiting for a lock so check again.
+	if service, ok := m.instances[typ]; ok {
+		return service, nil
+	}
+	// Build, save, and return the scoped instance.
+	service, err := factory(resolver)
+	if err != nil {
+		return nil, err
+	}
+	if m.instances == nil {
+		m.instances = make(map[reflect.Type]any)
+	}
+	m.instances[typ] = service
+	return service, nil
+}
+
+func (m *instanceMap) get(typ reflect.Type) (any, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.instances[typ]
+	return v, ok
+}
+
+func (m *instanceMap) values() []any {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	values := make([]any, 0, len(m.instances))
+	for _, v := range m.instances {
+		values = append(values, v)
+	}
+	return values
+}

--- a/pkg/di/root_provider_test.go
+++ b/pkg/di/root_provider_test.go
@@ -10,6 +10,25 @@ func TestRootProvider(t *testing.T) {
 
 	t.Run("Resolve", func(t *testing.T) {
 
+		t.Run("returns UnknownType for unknown type", func(t *testing.T) {
+			expectedType := reflect.TypeFor[struct{}]()
+			provider, err := Registry{}.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			_, err = provider.Resolve(expectedType)
+			if !errors.Is(err, ErrUnknownType) {
+				t.Fatalf("expected %q; got %q", ErrUnknownType, err)
+			}
+			var unknownType UnknownType
+			if !errors.As(err, &unknownType) {
+				t.Fatalf("expected %v to be %T", err, unknownType)
+			}
+			if unknownType.Type != expectedType {
+				t.Errorf("expected err.Type to be %v; got %v", expectedType, unknownType.Type)
+			}
+		})
+
 		// distinctCapableStruct is required to observe whether pointers point to the same instance
 		// or not because pointers to zero-length structs can be equal even when the pointed values
 		// are distinct.

--- a/pkg/di/scope.go
+++ b/pkg/di/scope.go
@@ -1,0 +1,94 @@
+package di
+
+import (
+	"context"
+	"reflect"
+	"sync"
+)
+
+// A Scope is a [Provider] that can resolve [Scoped] values in addition to [Transient] and
+// [Singleton] values. A Scope will create a single instance of a value for a type registered
+type Scope struct {
+	root         *RootProvider
+	scopedValues *instanceMap
+}
+
+// NewScope creates a new [Scope] which can resolve [Scoped] values as well as [Transient]
+// and [Singleton] values.
+func (scope Scope) NewScope() Scope {
+	return scope.root.NewScope()
+}
+
+// Resolve returns an instance of the requested type if it was registered.
+func (scope Scope) Resolve(typ reflect.Type) (any, error) {
+	registration, ok := scope.root.registrations[typ]
+	if ok && registration.lifetime == Scoped {
+		return scope.scopedValues.resolve(typ, registration.factory, scope)
+	}
+	return scope.root.Resolve(typ)
+}
+
+// A ContextCloser is a value that can be closed with a [context.Context].
+type ContextCloser interface {
+	Close(context.Context) error
+}
+
+// A Closer is a value that can be closed.
+type Closer interface {
+	Close() error
+}
+
+func (scope Scope) Close(ctx context.Context) []error {
+
+	values := scope.scopedValues.values()
+	contextClosers := make([]ContextCloser, 0, len(values))
+	closers := make([]Closer, 0, len(values))
+	for _, value := range values {
+		if contextCloser, ok := value.(ContextCloser); ok {
+			contextClosers = append(contextClosers, contextCloser)
+			continue
+		}
+		if closer, ok := value.(Closer); ok {
+			closers = append(closers, closer)
+		}
+	}
+
+	n := len(contextClosers) + len(closers)
+	closeErrorsCh := make(chan error, n)
+	closeErrors := make([]error, 0, n)
+
+	wg := sync.WaitGroup{}
+	wg.Add(n)
+	wgDone := make(chan struct{})
+	go func() {
+		defer close(wgDone)
+		wg.Wait()
+	}()
+
+	for _, contextCloser := range contextClosers {
+		go func() {
+			defer wg.Done()
+			closeErrorsCh <- contextCloser.Close(ctx)
+		}()
+	}
+
+	for _, closer := range closers {
+		go func() {
+			defer wg.Done()
+			closeErrorsCh <- closer.Close()
+		}()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return closeErrors
+		case <-wgDone:
+			return closeErrors
+		case err := <-closeErrorsCh:
+			if err != nil {
+				closeErrors = append(closeErrors, err)
+			}
+		}
+	}
+}

--- a/pkg/di/scope_test.go
+++ b/pkg/di/scope_test.go
@@ -1,0 +1,444 @@
+package di
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestScope(t *testing.T) {
+
+	t.Run("Resolve", func(t *testing.T) {
+
+		t.Run("returns UnknownType for unknown type", func(t *testing.T) {
+			expectedType := reflect.TypeFor[struct{}]()
+			provider, err := Registry{}.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			_, err = scope.Resolve(expectedType)
+			if !errors.Is(err, ErrUnknownType) {
+				t.Fatalf("expected %q; got %q", ErrUnknownType, err)
+			}
+			var unknownType UnknownType
+			if !errors.As(err, &unknownType) {
+				t.Fatalf("expected %v to be %T", err, unknownType)
+			}
+			if unknownType.Type != expectedType {
+				t.Errorf("expected err.Type to be %v; got %v", expectedType, unknownType.Type)
+			}
+		})
+
+		// distinctCapableStruct is required to observe whether pointers point to the same instance
+		// or not because pointers to zero-length structs can be equal even when the pointed values
+		// are distinct.
+		//
+		// From the Golang spec:
+		// Pointer types are comparable. Two pointer values are equal if they point to the same
+		// variable or if both have value nil. Pointers to distinct zero-size variables may or may
+		// not be equal.
+		type distinctCapableStruct struct {
+			//lint:ignore U1000 Field enabled type to be distinct
+			x int
+		}
+
+		t.Run("transient instances from the same scope are distinct", func(t *testing.T) {
+			registry, err := RegisterType[*distinctCapableStruct, *distinctCapableStruct](Registry{}, Transient)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			a, err := scope.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			b, err := scope.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			if a == b {
+				t.Fatalf("instances are the same: %p %p", a, b)
+			}
+		})
+
+		t.Run("singleton instances from the same scope are the same", func(t *testing.T) {
+			registry, err := RegisterType[*distinctCapableStruct, *distinctCapableStruct](Registry{}, Singleton)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			a, err := scope.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			b, err := scope.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			if a != b {
+				t.Fatalf("instances are not the same: %p %p", a, b)
+			}
+		})
+
+		t.Run("scoped instances from the same scope are the same", func(t *testing.T) {
+			registry, err := RegisterType[*distinctCapableStruct, *distinctCapableStruct](Registry{}, Scoped)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			a, err := scope.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			b, err := scope.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			if a != b {
+				t.Fatalf("instances are not the same: %p %p", a, b)
+			}
+		})
+
+		t.Run("scoped instances from different scopes are distinct", func(t *testing.T) {
+			registry, err := RegisterType[*distinctCapableStruct, *distinctCapableStruct](Registry{}, Scoped)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scopeA := provider.NewScope()
+			a, err := scopeA.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			scopeB := provider.NewScope()
+			b, err := scopeB.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			if a == b {
+				t.Fatalf("instances are the same: %p %p", a, b)
+			}
+		})
+
+		t.Run("scoped instances from descendant scopes are distinct", func(t *testing.T) {
+			registry, err := RegisterType[*distinctCapableStruct, *distinctCapableStruct](Registry{}, Scoped)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scopeA := provider.NewScope()
+			a, err := scopeA.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			scopeB := scopeA.NewScope()
+			b, err := scopeB.Resolve(reflect.TypeFor[*distinctCapableStruct]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			if a == b {
+				t.Fatalf("instances are the same: %p %p", a, b)
+			}
+		})
+	})
+
+	t.Run("Close", func(t *testing.T) {
+
+		t.Run("closes ContextCloser values", func(t *testing.T) {
+			registry, err := RegisterType[*mockContextCloser, *mockContextCloser](Registry{}, Scoped)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			resolved, err := scope.Resolve(reflect.TypeFor[*mockContextCloser]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			closer, ok := resolved.(*mockContextCloser)
+			if !ok {
+				t.Fatalf("expected Resolve to return %T; got %T", closer, resolved)
+			}
+			if errs := scope.Close(context.Background()); len(errs) != 0 {
+				t.Fatalf("unexpected errors from Close: %v", errs)
+			}
+			if !closer.closed {
+				t.Fatalf("closer was not closed")
+			}
+		})
+
+		t.Run("returns errors from ContextCloser values", func(t *testing.T) {
+			expectedErr := errors.New("expected error")
+			registry, err := RegisterFactory[*errorContextCloser](Registry{}, Scoped, func(Resolver) (*errorContextCloser, error) {
+				return &errorContextCloser{
+					err: expectedErr,
+				}, nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			_, err = scope.Resolve(reflect.TypeFor[*errorContextCloser]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			errs := scope.Close(context.Background())
+			if len(errs) != 1 {
+				t.Fatalf("expected 1 error, got %d (%v)", len(errs), errs)
+			}
+			if !errors.Is(errs[0], expectedErr) {
+				t.Fatalf("expected errs[0] to be %v; got %v", expectedErr, errs[0])
+			}
+		})
+
+		t.Run("closes Closer values", func(t *testing.T) {
+			registry, err := RegisterType[*mockCloser, *mockCloser](Registry{}, Scoped)
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			resolved, err := scope.Resolve(reflect.TypeFor[*mockCloser]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			closer, ok := resolved.(*mockCloser)
+			if !ok {
+				t.Fatalf("expected Resolve to return %T; got %T", closer, resolved)
+			}
+			if errs := scope.Close(context.Background()); len(errs) != 0 {
+				t.Fatalf("unexpected errors from Close: %v", errs)
+			}
+			if !closer.closed {
+				t.Fatalf("closer was not closed")
+			}
+		})
+
+		t.Run("returns errors from Closer values", func(t *testing.T) {
+			expectedErr := errors.New("expected error")
+			registry, err := RegisterFactory[*errorCloser](Registry{}, Scoped, func(Resolver) (*errorCloser, error) {
+				return &errorCloser{
+					err: expectedErr,
+				}, nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			_, err = scope.Resolve(reflect.TypeFor[*errorCloser]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			errs := scope.Close(context.Background())
+			if len(errs) != 1 {
+				t.Fatalf("expected 1 error, got %d (%v)", len(errs), errs)
+			}
+			if !errors.Is(errs[0], expectedErr) {
+				t.Fatalf("expected errs[0] to be %v; got %v", expectedErr, errs[0])
+			}
+		})
+
+		t.Run("returns multiple errors from ContextCloser and Closer values", func(t *testing.T) {
+			expectedErrs := []error{
+				errors.New("first expected error"),
+				errors.New("second expected error"),
+				errors.New("third expected error"),
+			}
+			registry, err := RegisterFactory[*errorContextCloser](Registry{}, Scoped, func(Resolver) (*errorContextCloser, error) {
+				return &errorContextCloser{
+					err: expectedErrs[0],
+				}, nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			registry, err = RegisterFactory[*errorCloser](registry, Scoped, func(Resolver) (*errorCloser, error) {
+				return &errorCloser{
+					err: expectedErrs[1],
+				}, nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			registry, err = RegisterFactory[*errorContextCloser2](registry, Scoped, func(Resolver) (*errorContextCloser2, error) {
+				return &errorContextCloser2{
+					err: expectedErrs[2],
+				}, nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			_, err = scope.Resolve(reflect.TypeFor[*errorContextCloser]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			_, err = scope.Resolve(reflect.TypeFor[*errorCloser]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			_, err = scope.Resolve(reflect.TypeFor[*errorContextCloser2]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			errs := scope.Close(context.Background())
+			if len(errs) != len(expectedErrs) {
+				t.Fatalf("expected %d error, got %d (%v)", len(expectedErrs), len(errs), errs)
+			}
+			found := 0
+			for _, err := range errs {
+				for _, expectedErr := range expectedErrs {
+					if errors.Is(err, expectedErr) {
+						found++
+						continue
+					}
+				}
+			}
+			if found != len(expectedErrs) {
+				t.Fatalf("expected errs to be %v; got %v", expectedErrs, errs)
+			}
+		})
+
+		t.Run("gives up on blocking calls when context is Done", func(t *testing.T) {
+			unexpectedErrs := []error{
+				errors.New("first unexpected error"),
+				errors.New("second unexpected error"),
+			}
+			registry, err := RegisterFactory[*blockingContextCloser](Registry{}, Scoped, func(Resolver) (*blockingContextCloser, error) {
+				return &blockingContextCloser{
+					blockTime: time.Second,
+					err:       unexpectedErrs[0],
+				}, nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			registry, err = RegisterFactory[*blockingCloser](registry, Scoped, func(Resolver) (*blockingCloser, error) {
+				return &blockingCloser{
+					blockTime: time.Second,
+					err:       unexpectedErrs[1],
+				}, nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error from RegisterType: %v", err)
+			}
+			provider, err := registry.BuildRootProvider()
+			if err != nil {
+				t.Fatalf("unexpected error from BuildRootProvider: %v", err)
+			}
+			scope := provider.NewScope()
+			_, err = scope.Resolve(reflect.TypeFor[*blockingContextCloser]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			_, err = scope.Resolve(reflect.TypeFor[*blockingCloser]())
+			if err != nil {
+				t.Fatalf("unexpected error from Resolve: %v", err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+			defer cancel()
+			if errs := scope.Close(ctx); len(errs) != 0 {
+				t.Fatalf("unexpected errors from Close: %v", errs)
+			}
+		})
+	})
+}
+
+type mockContextCloser struct {
+	closed bool
+}
+
+func (m *mockContextCloser) Close(context.Context) error {
+	m.closed = true
+	return nil
+}
+
+type mockCloser struct {
+	closed bool
+}
+
+func (m *mockCloser) Close() error {
+	m.closed = true
+	return nil
+}
+
+type errorContextCloser struct {
+	err error
+}
+
+func (m *errorContextCloser) Close(context.Context) error {
+	return m.err
+}
+
+type errorCloser struct {
+	err error
+}
+
+func (m *errorCloser) Close() error {
+	return m.err
+}
+
+type errorContextCloser2 errorContextCloser
+
+func (m *errorContextCloser2) Close(context.Context) error {
+	return m.err
+}
+
+type blockingContextCloser struct {
+	blockTime time.Duration
+	err       error
+}
+
+func (m *blockingContextCloser) Close(context.Context) error {
+	<-time.After(m.blockTime)
+	return m.err
+}
+
+type blockingCloser struct {
+	blockTime time.Duration
+	err       error
+}
+
+func (m *blockingCloser) Close(context.Context) error {
+	<-time.After(m.blockTime)
+	return m.err
+}


### PR DESCRIPTION
Implements resolution scopes to support sharing instances in user-defined scopes such as when handling HTTP requests. Scoped values implementing the ContextCloser or Closer interfaces are closed when the the Scope is closed to help support deterministic lifetimes.