### PR TITLE
chore: express memory model consistently

### DIFF
--- a/pkg/di/root_provider.go
+++ b/pkg/di/root_provider.go
@@ -61,7 +61,7 @@ type RootProvider struct {
 
 // NewScope creates a new [Scope] which can resolve [Scoped] values as well as [Transient]
 // and [Singleton] values.
-func (provider *RootProvider) NewScope() Scope {
+func (provider RootProvider) NewScope() Scope {
 	return Scope{
 		root:         provider,
 		scopedValues: &instanceMap{},

--- a/pkg/di/scope.go
+++ b/pkg/di/scope.go
@@ -9,7 +9,7 @@ import (
 // A Scope is a [Provider] that can resolve [Scoped] values in addition to [Transient] and
 // [Singleton] values. A Scope will create a single instance of a value for a type registered
 type Scope struct {
-	root         *RootProvider
+	root         RootProvider
 	scopedValues *instanceMap
 }
 


### PR DESCRIPTION
The RootProvider and Scope types hold pointers to their registrations and shared value pools meaning that copies of these types are views ino the same shared data. This ensures there is no need to use pointers to these types. The previous implementation had the correct behaviour but used pointers where they were not necessary.

- The Scope type held a pointer to a RootProvider instead of a RootProvider.

- The NewScope method on the RootProvider type took a pointer receiver instead of a value receiver.

No testing has been done to determine the use of pointers for method receivers and/or the Scope type holding pointers to the RootProvider have meaningful performance implications -- this change is being made only for the sake of consistency with the intention that these types can be used without pointers.